### PR TITLE
Leaderboard Optimizations

### DIFF
--- a/src/components/Leaderboard/LeaderBoardSection.tsx
+++ b/src/components/Leaderboard/LeaderBoardSection.tsx
@@ -1,17 +1,46 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { LeaderboardListS1 } from "./LeaderboardListS1";
 import { LeaderboardListS2 } from "./LeaderboardListS2";
 import { Box, Text } from "../../blocks";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  getRewardsLeaderboardS1,
+  getRewardsLeaderboardS2,
+  rewardsLeaderboardS1,
+  rewardsLeaderboardS2,
+} from "../../queries";
 
 export type LeaderBoardSectionProps = Record<string, never>;
 
 const LeaderBoardSection: FC<LeaderBoardSectionProps> = () => {
   const location = useLocation();
+  const queryClient = useQueryClient();
 
-  const season = location?.pathname?.includes("s1") ? "S1" : "S2";
+  const [season, setSeason] = useState(() =>
+    location.pathname.includes("s1") ? "S1" : "S2",
+  );
+
+  useEffect(() => {
+    const newSeason = location.pathname.includes("s1") ? "S1" : "S2";
+    setSeason(newSeason);
+
+    if (newSeason === "S1") {
+      queryClient.removeQueries({ queryKey: [rewardsLeaderboardS2] }); // Clear S2 cache
+      queryClient.prefetchInfiniteQuery({
+        queryKey: [rewardsLeaderboardS1],
+        queryFn: getRewardsLeaderboardS1,
+      });
+    } else {
+      queryClient.removeQueries({ queryKey: [rewardsLeaderboardS1] }); // Clear S1 cache
+      queryClient.prefetchInfiniteQuery({
+        queryKey: [rewardsLeaderboardS2],
+        queryFn: getRewardsLeaderboardS2,
+      });
+    }
+  }, [location.pathname, queryClient]);
 
   return (
     <Box
@@ -35,7 +64,7 @@ const LeaderBoardSection: FC<LeaderBoardSectionProps> = () => {
         Leaderboard {season}
       </Text>
 
-      {season === "S1" ? <LeaderboardListS1 /> : <LeaderboardListS2 />}
+      {season == "S1" ? <LeaderboardListS1 /> : <LeaderboardListS2 />}
     </Box>
   );
 };

--- a/src/components/Leaderboard/LeaderboardListItem.tsx
+++ b/src/components/Leaderboard/LeaderboardListItem.tsx
@@ -43,7 +43,7 @@ const LeaderboardListItem: FC<LeaderboardListItemProps> = ({
         border-bottom: var(--border-sm) solid var(--stroke-secondary);
       `}
     >
-      <Skeleton isLoading={isLoading}>
+      <Skeleton isLoading={isLoading} width={{ initial: "250px", tb: "auto" }}>
         <Box display="flex" gap="spacing-xs" alignItems="center">
           <Box width="34px" justifyContent="center" display="flex">
             <Text variant="bm-bold" color="text-primary">

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -10,6 +10,6 @@ export const pushStakeEpoch = "pushStakeEpoch";
 export const rewardActivityStatus = "rewardActivityStatus";
 export const rewardsActivity = "rewardsActivity";
 export const rewardsLeaderboardS1 = "rewardsLeaderboardS1";
-export const rewardsLeaderboardS2 = "rewardsLeaderboardS1";
+export const rewardsLeaderboardS2 = "rewardsLeaderboardS2";
 export const tweetStatus = "tweetStatus";
 export const userRewardsDetails = "userRewardsDetails";


### PR DESCRIPTION
- When you switch tabs in leaderboard, the pages and data gets mixed up. This fixes it, by removing s1 cache when in s2 and vice-versa and refetch fresh data on page onload. 